### PR TITLE
Update urlparse import to work with python3.12

### DIFF
--- a/hg-dumper.py
+++ b/hg-dumper.py
@@ -8,7 +8,7 @@ import re
 import socket
 import subprocess
 import sys
-import urlparse
+import urllib.parse as urlparse
 
 import bs4
 import mercurial.dispatch


### PR DESCRIPTION
Thanks for the tool ... just a small update for it to function with Python 3.12. 